### PR TITLE
updated rbac role and service account

### DIFF
--- a/k8s_TWS/apache/Roles.yml
+++ b/k8s_TWS/apache/Roles.yml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: 
+  name: apache-manager
+  namespace: apache
+rules:
+  - apiGroups: ["*"]
+    resources: ["pod","deployment","service"]
+    verbs: ["apply","get","watch","create","list"]

--- a/k8s_TWS/apache/serviceAccount.yml
+++ b/k8s_TWS/apache/serviceAccount.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata: 
+  name: apache-user
+  namespace: apache
+


### PR DESCRIPTION
proceed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new Role `apache-manager` with permissions to manage pods, deployments, and services in the Apache namespace
  - Created a new ServiceAccount `apache-user` in the Apache namespace to manage access control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->